### PR TITLE
Fix one error regarding xml code inside html

### DIFF
--- a/html_similarity/structural_similarity.py
+++ b/html_similarity/structural_similarity.py
@@ -18,6 +18,8 @@ def get_tags(doc):
             tags.append(el.tag)
         elif isinstance(el, lxml.html.HtmlComment):
             tags.append('comment')
+        elif isinstance(el, lxml.html.HtmlProcessingInstruction):
+            tags.append(el.tag)
         else:
             raise ValueError('Don\'t know what to do with element: {}'.format(el))
 


### PR DESCRIPTION
Dear matiskay,

I am using your library to compare http and https Portuguese websites.
Some of the websites still use XML inside HTML.
I added one condition to your code to support lxml.html.HtmlProcessingInstruction (the XML tags were as the previously mentioned class).
Can you add this fix to your code?

Thanks,
Catarina 