### PR TITLE
Support load html from bytes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 build/
 dist/
 .cache
+.venv/

--- a/html_similarity/structural_similarity.py
+++ b/html_similarity/structural_similarity.py
@@ -1,5 +1,5 @@
 import difflib
-from io import StringIO
+from io import BytesIO, StringIO
 
 import lxml.html
 
@@ -32,8 +32,8 @@ def structural_similarity(document_1, document_2):
     :return: int
     """
     try:
-        document_1 = lxml.html.parse(StringIO(document_1))
-        document_2 = lxml.html.parse(StringIO(document_2))
+        document_1 = lxml.html.parse(StringIO(document_1) if isinstance(document_1, str) else BytesIO(document_1))
+        document_2 = lxml.html.parse(StringIO(document_2) if isinstance(document_2, str) else BytesIO(document_2))
     except Exception as e:
         print(e)
         return 0

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -1,8 +1,8 @@
 from html_similarity import style_similarity
 from html_similarity.style_similarity import jaccard_similarity
+from html_similarity import structural_similarity
 
 from .utils import almost_equal
-
 
 html1 = ''''
 <html>
@@ -44,3 +44,36 @@ def test_jaccard_similarity():
     assert almost_equal(0.6666, jaccard_similarity(['a', 'b'], ['a', 'b', 'c']))
     assert 0 == jaccard_similarity(['d', 'e'], ['a', 'b', 'c'])
     assert almost_equal(jaccard_similarity(list(range(1, 1000000)), list(range(1000000 - 10, 2 * 1000000))), 0)
+
+xhtml_1 = '''
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html>
+    <body class="body-class">
+        <h1 class="title">This a title<h1>
+        <ul>
+            <li class="item active">item 1</li>
+            <li class="item">item 2</li>
+            <li class="item">item 3</li>
+        <ul>
+    </body>
+</html>
+'''
+
+xhtml_2 = '''
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html>
+    <body class="body-class">
+        <h1 class="title">This a different title<h1>
+        <ul>
+            <li class="item active">item 1</li>
+            <li class="item">item 2</li>
+            <li class="item">item 3</li>
+        <ul>
+    </body>
+</html>
+'''
+
+def test_bytes_similarity():
+    assert 1 == structural_similarity(xhtml_1.encode('utf-8'), xhtml_2.encode('utf-8'))


### PR DESCRIPTION
Add support to load documents from byte arrays.

We have to deal with some xhtml documents that have processing instructions on the beginning like the following one:

```xhtml
<?xml version="1.0" encoding="UTF-8" ?>
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
<html>
    <body>
    </body>
</html>
```

These ones can not be loaded from strings because `xml.html.parse` do not support the encoding instruction when source is string.
