### PR TITLE
🏷️ Add type hints to html_similarity modules

### DIFF
--- a/html_similarity/similarity.py
+++ b/html_similarity/similarity.py
@@ -2,5 +2,5 @@ from html_similarity.style_similarity import style_similarity
 from html_similarity.structural_similarity import structural_similarity
 
 
-def similarity(document_1, document_2, k=0.5):
+def similarity(document_1: str, document_2: str, k: float = 0.5) -> float:
     return k * structural_similarity(document_1, document_2) + (1 - k) * style_similarity(document_1, document_2)

--- a/html_similarity/structural_similarity.py
+++ b/html_similarity/structural_similarity.py
@@ -2,16 +2,17 @@ import difflib
 from io import StringIO
 
 import lxml.html
+from lxml.etree import _ElementTree
 
 
-def get_tags(doc):
+def get_tags(doc: _ElementTree) -> list[str]:
     '''
     Get tags from a DOM tree
 
     :param doc: lxml parsed object
     :return:
     '''
-    tags = list()
+    tags: list[str] = []
 
     for el in doc.getroot().iter():
         if isinstance(el, lxml.html.HtmlElement):
@@ -24,7 +25,7 @@ def get_tags(doc):
     return tags
 
 
-def structural_similarity(document_1, document_2):
+def structural_similarity(document_1: str, document_2: str) -> float:
     """
     Computes the structural similarity between two DOM Trees
     :param document_1: html string
@@ -32,14 +33,14 @@ def structural_similarity(document_1, document_2):
     :return: int
     """
     try:
-        document_1 = lxml.html.parse(StringIO(document_1))
-        document_2 = lxml.html.parse(StringIO(document_2))
+        tree_1 = lxml.html.parse(StringIO(document_1))
+        tree_2 = lxml.html.parse(StringIO(document_2))
     except Exception as e:
         print(e)
         return 0
 
-    tags1 = get_tags(document_1)
-    tags2 = get_tags(document_2)
+    tags1 = get_tags(tree_1)
+    tags2 = get_tags(tree_2)
     diff = difflib.SequenceMatcher()
     diff.set_seq1(tags1)
     diff.set_seq2(tags2)

--- a/html_similarity/style_similarity.py
+++ b/html_similarity/style_similarity.py
@@ -1,17 +1,19 @@
+from collections.abc import Iterable
+
 from parsel import Selector
 
 
-def get_classes(html):
+def get_classes(html: str) -> set[str]:
     doc = Selector(text=html)
     classes = set(doc.xpath('//*[@class]/@class').extract())
-    result = set()
+    result: set[str] = set()
     for cls in classes:
         for _cls in cls.split():
             result.add(_cls)
     return result
 
 
-def jaccard_similarity(set1, set2):
+def jaccard_similarity(set1: Iterable[str], set2: Iterable[str]) -> float:
     set1 = set(set1)
     set2 = set(set2)
     intersection = len(set1 & set2)
@@ -23,7 +25,7 @@ def jaccard_similarity(set1, set2):
     return intersection / max(denominator, 0.000001)
 
 
-def style_similarity(page1, page2):
+def style_similarity(page1: str, page2: str) -> float:
     """
     Computes CSS style Similarity between two DOM trees
 


### PR DESCRIPTION
## Summary

- Add type annotations to `similarity`, `structural_similarity`, and `style_similarity` functions/modules

## Test plan

- [x] `pytest` passes (3 passed)