### PR TITLE
✨ Support loading HTML from bytes in structural_similarity

### DIFF
--- a/html_similarity/structural_similarity.py
+++ b/html_similarity/structural_similarity.py
@@ -1,5 +1,5 @@
 import difflib
-from io import StringIO
+from io import BytesIO, StringIO
 
 import lxml.html
 from lxml.etree import _ElementTree
@@ -25,16 +25,16 @@ def get_tags(doc: _ElementTree) -> list[str]:
     return tags
 
 
-def structural_similarity(document_1: str, document_2: str) -> float:
+def structural_similarity(document_1: str | bytes, document_2: str | bytes) -> float:
     """
     Computes the structural similarity between two DOM Trees
-    :param document_1: html string
-    :param document_2: html string
+    :param document_1: html string or bytes
+    :param document_2: html string or bytes
     :return: int
     """
     try:
-        tree_1 = lxml.html.parse(StringIO(document_1))
-        tree_2 = lxml.html.parse(StringIO(document_2))
+        tree_1 = lxml.html.parse(StringIO(document_1) if isinstance(document_1, str) else BytesIO(document_1))
+        tree_2 = lxml.html.parse(StringIO(document_2) if isinstance(document_2, str) else BytesIO(document_2))
     except Exception as e:
         print(e)
         return 0

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -1,4 +1,4 @@
-from html_similarity import style_similarity
+from html_similarity import structural_similarity, style_similarity
 from html_similarity.style_similarity import jaccard_similarity
 
 from .utils import almost_equal
@@ -44,3 +44,38 @@ def test_jaccard_similarity():
     assert almost_equal(0.6666, jaccard_similarity(['a', 'b'], ['a', 'b', 'c']))
     assert 0 == jaccard_similarity(['d', 'e'], ['a', 'b', 'c'])
     assert almost_equal(jaccard_similarity(list(range(1, 1000000)), list(range(1000000 - 10, 2 * 1000000))), 0)
+
+
+xhtml1 = '''
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html>
+    <body class="body-class">
+        <h1 class="title">This a title<h1>
+        <ul>
+            <li class="item active">item 1</li>
+            <li class="item">item 2</li>
+            <li class="item">item 3</li>
+        <ul>
+    </body>
+</html>
+'''
+
+xhtml2 = '''
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html>
+    <body class="body-class">
+        <h1 class="title">This a different title<h1>
+        <ul>
+            <li class="item active">item 1</li>
+            <li class="item">item 2</li>
+            <li class="item">item 3</li>
+        <ul>
+    </body>
+</html>
+'''
+
+
+def test_structural_similarity_from_bytes():
+    assert 1 == structural_similarity(xhtml1.encode('utf-8'), xhtml2.encode('utf-8'))


### PR DESCRIPTION
## Summary

- `structural_similarity` now accepts `str | bytes` for both documents, parsing via `BytesIO` when given bytes
- Needed for XHTML documents with an `<?xml version="1.0" encoding="UTF-8" ?>` declaration, which `lxml.html.parse` rejects when passed as a `str`
- `style_similarity`/`similarity()` remain `str`\-only since `parsel.Selector` doesn't accept bytes

## Credits

Ports the approach from @beppler's PR matiskay/html-similarity#107, adapted to this branch's type-hinted signatures.

## Test plan

- [x] Added `test_structural_similarity_from_bytes` (adapted from #107) covering the XHTML-with-encoding-declaration case
- [x] `pytest` passes (4 passed)