### PR TITLE
🔧 Add Dependabot config for uv and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "10:00"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "10:00"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` to enable automated weekly dependency update PRs
- Use the `uv` ecosystem (not `pip`) since the project now manages dependencies via `pyproject.toml`/`uv.lock`
- Also watch `github-actions` to keep the pinned actions in `.github/workflows/ci.yml` (`actions/checkout`, `astral-sh/setup-uv`) up to date

## Test plan

- [x] Validated YAML structure manually