### PR TITLE
🐛 Handle HtmlProcessingInstruction nodes in get_tags

### DIFF
--- a/html_similarity/structural_similarity.py
+++ b/html_similarity/structural_similarity.py
@@ -19,6 +19,8 @@ def get_tags(doc: _ElementTree) -> list[str]:
             tags.append(el.tag)
         elif isinstance(el, lxml.html.HtmlComment):
             tags.append('comment')
+        elif isinstance(el, lxml.html.HtmlProcessingInstruction):
+            tags.append('processing-instruction')
         else:
             raise ValueError('Don\'t know what to do with element: {}'.format(el))
 

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -1,4 +1,8 @@
+import lxml.html
+from lxml import etree
+
 from html_similarity import structural_similarity, style_similarity
+from html_similarity.structural_similarity import get_tags
 from html_similarity.style_similarity import jaccard_similarity
 
 from .utils import almost_equal
@@ -79,3 +83,12 @@ xhtml2 = '''
 
 def test_structural_similarity_from_bytes():
     assert 1 == structural_similarity(xhtml1.encode('utf-8'), xhtml2.encode('utf-8'))
+
+
+def test_get_tags_with_processing_instruction():
+    root = lxml.html.fromstring('<html><body><h1 class="title">hi</h1></body></html>')
+    root.find('body').insert(0, lxml.html.HtmlProcessingInstruction('php', 'echo 1;'))
+
+    tags = get_tags(etree.ElementTree(root))
+
+    assert tags == ['html', 'body', 'processing-instruction', 'h1']


### PR DESCRIPTION
## Summary
- `get_tags` now recognizes `lxml.html.HtmlProcessingInstruction` nodes (e.g. embedded PHP tags, MS Office XML namespace declarations) instead of raising `ValueError`
- Appends the literal `'processing-instruction'`, consistent with how `HtmlComment` nodes are already handled (`'comment'`), rather than `el.tag` which is a non-string cyfunction object for PI nodes
## Credits
Based on matiskay/html-similarity#51 by @catarinaacsilva. Adapted the fix to append a string label instead of `el.tag`, since `.tag` on a processing instruction isn't a string and would break the typed `list[str]` return / `difflib` comparisons.
## Test plan
- [x] Added `test_get_tags_with_processing_instruction`, building the tree programmatically since current lxml/libxml2 normalizes `<? ?>` syntax to comments during HTML parsing rather than producing real PI nodes
- [x] `pytest` passes (5 passed)
- [x] `flake8` clean