### PR TITLE
📦 Add lxml as an explicit dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
+    "lxml>=5.0",
     "parsel>=1.10",
 ]
 


### PR DESCRIPTION
## **Summary**

- `html_similarity/structural_similarity.py` imports `lxml.html` and uses `lxml.etree._ElementTree` directly, but `pyproject.toml` only declared `parsel>=1.10`. It worked only because `parsel` happens to pull in `lxml` transitively — not a guaranteed contract, and a future `parsel` release that relaxes or drops its `lxml` pin could silently break installs.
- Declares `lxml>=5.0` explicitly in `[project.dependencies]` to match what the code actually imports.

## **Test plan**

- [x] `uv lock` — `uv.lock` resolves with no changes to the pinned `lxml` version (already 6.1.1 transitively)
- [x] `uv run pytest -v tests/` — 5/5 passed