### PR TITLE
🐛 Disable difflib autojunk to fix structural_similarity on large documents

### DIFF
--- a/html_similarity/structural_similarity.py
+++ b/html_similarity/structural_similarity.py
@@ -43,7 +43,7 @@ def structural_similarity(document_1: str | bytes, document_2: str | bytes) -> f
 
     tags1 = get_tags(tree_1)
     tags2 = get_tags(tree_2)
-    diff = difflib.SequenceMatcher()
+    diff = difflib.SequenceMatcher(autojunk=False)
     diff.set_seq1(tags1)
     diff.set_seq2(tags2)
 

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -92,3 +92,19 @@ def test_get_tags_with_processing_instruction():
     tags = get_tags(etree.ElementTree(root))
 
     assert tags == ['html', 'body', 'processing-instruction', 'h1']
+
+
+def test_structural_similarity_ignores_autojunk_on_large_repetitive_documents():
+    # difflib.SequenceMatcher's default autojunk=True treats elements occurring
+    # in >1% of positions as "popular" and excludes them from matching once a
+    # sequence has >=200 items. Long HTML documents are dominated by a handful
+    # of repeated tags (div, li, span, ...), which is exactly this case, so the
+    # default would badly understate similarity between near-identical pages.
+    def make_html(n, first_tag):
+        body = f'<{first_tag}>x</{first_tag}>' + '<div>x</div>' * (n - 1)
+        return f'<html><body>{body}</body></html>'
+
+    doc1 = make_html(250, 'div')
+    doc2 = make_html(250, 'span')  # differs in exactly 1 of 251 tags
+
+    assert almost_equal(structural_similarity(doc1, doc2), 250 / 251, threshold=0.01)


### PR DESCRIPTION
## **Summary**

- `difflib.SequenceMatcher`'s default `autojunk=True` marks any element occurring in >1% of positions as "popular" and excludes it from matching once a sequence has ≥200 items. HTML documents are dominated by a handful of repeated tags (`div`, `li`, `span`...), so this silently corrupted scores on real pages — two 251-tag documents differing in exactly 1 tag scored **0\.0079** instead of ~0.996.
- Pass `autojunk=False` to `difflib.SequenceMatcher` in `structural_similarity.py:46`.

## **Test plan**

- [x] Added `test_structural_similarity_ignores_autojunk_on_large_repetitive_documents`, which fails on the old code (asserts ~0.996, got 0.0079) and passes after the fix
- [x] `uv run pytest -v tests/` — 6/6 passed
- [x] `uv run flake8 html_similarity` — clean