### PR TITLE
🛡️ Raise HtmlParsingError instead of silently returning 0.0 on parse failure

### DIFF
--- a/html_similarity/__init__.py
+++ b/html_similarity/__init__.py
@@ -1,6 +1,7 @@
-__all__ = ['style_similarity', 'structural_similarity', 'similarity']
+__all__ = ['style_similarity', 'structural_similarity', 'similarity', 'HtmlParsingError']
 
 
+from html_similarity.exceptions import HtmlParsingError
 from html_similarity.style_similarity import style_similarity
 from html_similarity.structural_similarity import structural_similarity
 from html_similarity.similarity import similarity

--- a/html_similarity/exceptions.py
+++ b/html_similarity/exceptions.py
@@ -1,0 +1,2 @@
+class HtmlParsingError(Exception):
+    """Raised when an HTML document cannot be parsed by lxml."""

--- a/html_similarity/structural_similarity.py
+++ b/html_similarity/structural_similarity.py
@@ -2,7 +2,9 @@ import difflib
 from io import BytesIO, StringIO
 
 import lxml.html
-from lxml.etree import _ElementTree
+from lxml.etree import ParserError, XMLSyntaxError, _ElementTree
+
+from html_similarity.exceptions import HtmlParsingError
 
 
 def get_tags(doc: _ElementTree) -> list[str]:
@@ -32,14 +34,14 @@ def structural_similarity(document_1: str | bytes, document_2: str | bytes) -> f
     Computes the structural similarity between two DOM Trees
     :param document_1: html string or bytes
     :param document_2: html string or bytes
-    :return: int
+    :return: float
+    :raises HtmlParsingError: if either document cannot be parsed
     """
     try:
         tree_1 = lxml.html.parse(StringIO(document_1) if isinstance(document_1, str) else BytesIO(document_1))
         tree_2 = lxml.html.parse(StringIO(document_2) if isinstance(document_2, str) else BytesIO(document_2))
-    except Exception as e:
-        print(e)
-        return 0
+    except (XMLSyntaxError, ParserError) as e:
+        raise HtmlParsingError(f'Failed to parse HTML document: {e}') from e
 
     tags1 = get_tags(tree_1)
     tags2 = get_tags(tree_2)

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -1,7 +1,10 @@
+from unittest.mock import patch
+
 import lxml.html
+import pytest
 from lxml import etree
 
-from html_similarity import structural_similarity, style_similarity
+from html_similarity import HtmlParsingError, structural_similarity, style_similarity
 from html_similarity.structural_similarity import get_tags
 from html_similarity.style_similarity import jaccard_similarity
 
@@ -108,3 +111,15 @@ def test_structural_similarity_ignores_autojunk_on_large_repetitive_documents():
     doc2 = make_html(250, 'span')  # differs in exactly 1 of 251 tags
 
     assert almost_equal(structural_similarity(doc1, doc2), 250 / 251, threshold=0.01)
+
+
+def test_structural_similarity_raises_html_parsing_error_on_xml_syntax_error():
+    with patch('lxml.html.parse', side_effect=etree.XMLSyntaxError('boom', 0, 0, 0)):
+        with pytest.raises(HtmlParsingError):
+            structural_similarity('<html></html>', '<html></html>')
+
+
+def test_structural_similarity_raises_html_parsing_error_on_parser_error():
+    with patch('lxml.html.parse', side_effect=etree.ParserError('boom')):
+        with pytest.raises(HtmlParsingError):
+            structural_similarity('<html></html>', '<html></html>')


### PR DESCRIPTION
## **Summary**

- `structural_similarity` caught bare `Exception`, printed it to stdout, and returned `0.0` — indistinguishable from "completely dissimilar" documents, and could mask real bugs (not just malformed HTML).
- Added a new `HtmlParsingError` exception (exported from `html_similarity`), narrowed the catch to lxml's actual parse-failure types (`XMLSyntaxError`, `ParserError`), and raise it (chained via `from e`) instead of swallowing.
- Note: `lxml.html`'s default parser is very lenient — it recovers from empty input, garbage bytes, and non-HTML text rather than raising, so this exception path is rare in practice for real callers; it mainly guards against genuine edge cases and a future parser/recover-mode change.
- Fixed a docstring/type mismatch as a drive-by (`:return: int` → `:return: float`).

## **Breaking change**

Callers who relied on `structural_similarity` returning `0.0` on unparseable input will now get an `HtmlParsingError` instead. No existing test depended on the old behavior.

## **Test plan**

- [x] Added tests mocking `lxml.html.parse` to raise `XMLSyntaxError` / `ParserError`, asserting `HtmlParsingError` is raised
- [x] `uv run pytest -v tests/` — 8/8 passed
- [ ] `uv run flake8 html_similarity tests` — clean